### PR TITLE
[SRE-475] Optimization for Fetching Metrics

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -176,9 +176,7 @@ System.register(['lodash', './showdown.min.js', './query_builder'], function (_e
             if (this.fetching) {
               return this.fetching;
             }
-
-   
-
+            
             this.fetching = this.getMetrics().then(function (metrics) {
               _this._cached_metrics = _.map(metrics, function (metric) {
                 return {

--- a/dist/partials/query.editor.html
+++ b/dist/partials/query.editor.html
@@ -11,9 +11,14 @@
         <label class="gf-form-label query-keyword width-7">AGG</label>
         <metric-segment segment="ctrl.aggregationSegment" get-options="ctrl.getAggregations()" on-change="ctrl.aggregationChanged()"></metric-segment>
       </div>
-      <div class="gf-form">
+      <div class="gf-form-inline">
         <label class="gf-form-label query-keyword width-7">METRIC</label>
-        <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
+        <div class="gf-form max-width-30">
+          <input type="text" class="gf-form-input" ng-model="ctrl.metricKeyword" spellcheck='false' placeholder="Type keyword here">
+        </div>
+        <div ng-if="ctrl.metricKeyword">
+          <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
+        </div>
       </div>
       <div class="gf-form">
         <label class="gf-form-label query-keyword width-7">POST</label>

--- a/dist/partials/query.editor.html
+++ b/dist/partials/query.editor.html
@@ -14,11 +14,9 @@
       <div class="gf-form-inline">
         <label class="gf-form-label query-keyword width-7">METRIC</label>
         <div class="gf-form max-width-30">
-          <input type="text" class="gf-form-input" ng-model="ctrl.metricKeyword" spellcheck='false' placeholder="Type keyword here">
+          <input type="text" class="gf-form-input width-15" ng-model="ctrl.metricKeyword" spellcheck='false' placeholder="Type your keyword here">
         </div>
-        <div ng-if="ctrl.metricKeyword">
-          <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
-        </div>
+        <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
       </div>
       <div class="gf-form">
         <label class="gf-form-label query-keyword width-7">POST</label>

--- a/dist/query_ctrl.js
+++ b/dist/query_ctrl.js
@@ -300,9 +300,7 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
         }, {
           key: 'getMetrics',
           value: function getMetrics() {
-            if (this.metricKeyword && this.metricKeyword.length > 0) {
-              return this.datasource.initMetricsFetching(this.metricKeyword).then(this.uiSegmentSrv.transformToSegments(true));
-            }
+            return this.datasource.initMetricsFetching(this.metricKeyword).then(this.uiSegmentSrv.transformToSegments(true));
           }
         }, {
           key: 'getAggregations',

--- a/dist/query_ctrl.js
+++ b/dist/query_ctrl.js
@@ -203,7 +203,7 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
                 functions.push({
                   name: component,
                   defaultParams: []
-                });s
+                });
               } else {
                 /*
                 here it could have a metric, a scope

--- a/dist/query_ctrl.js
+++ b/dist/query_ctrl.js
@@ -300,7 +300,9 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
         }, {
           key: 'getMetrics',
           value: function getMetrics() {
-            return this.datasource.metricFindQuery().then(this.uiSegmentSrv.transformToSegments(true));
+            if (this.metricKeyword && this.metricKeyword.length > 0) {
+              return this.datasource.initMetricsFetching(this.metricKeyword).then(this.uiSegmentSrv.transformToSegments(true));
+            }
           }
         }, {
           key: 'getAggregations',

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -176,9 +176,7 @@ System.register(['lodash', './showdown.min.js', './query_builder'], function (_e
             if (this.fetching) {
               return this.fetching;
             }
-
-   
-
+            
             this.fetching = this.getMetrics().then(function (metrics) {
               _this._cached_metrics = _.map(metrics, function (metric) {
                 return {

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -1,83 +1,88 @@
 <query-editor-row query-ctrl="ctrl" has-text-edit-mode="true" can-collapse="true">
 
-  <div class="gf-form" ng-if="ctrl.target.rawQuery">
-    <input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" ng-blur="ctrl.checkQuery()"></input>
-  </div>
-
-  <div ng-if="!ctrl.target.rawQuery">
-
-    <div class="gf-form-inline">
-      <div class="gf-form">
-        <label class="gf-form-label query-keyword width-7">AGG</label>
-        <metric-segment segment="ctrl.aggregationSegment" get-options="ctrl.getAggregations()" on-change="ctrl.aggregationChanged()"></metric-segment>
-      </div>
-      <div class="gf-form">
-        <label class="gf-form-label query-keyword width-7">METRIC</label>
-        <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
-      </div>
-      <div class="gf-form">
-        <label class="gf-form-label query-keyword width-7">POST</label>
-        <metric-segment segment="ctrl.asSegment" get-options="ctrl.getAs()" on-change="ctrl.asChanged()"></metric-segment>
-      </div>
-
-      <div class="gf-form gf-form--grow">
-        <div class="gf-form-label gf-form-label--grow"></div> 
-      </div>
+    <div class="gf-form" ng-if="ctrl.target.rawQuery">
+      <input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" ng-blur="ctrl.checkQuery()"></input>
     </div>
-
-    <div class="gf-form-inline">
-      <div class="gf-form">
-        <label class="gf-form-label query-keyword width-7">SCOPE</label>
+  
+    <div ng-if="!ctrl.target.rawQuery">
+  
+      <div class="gf-form-inline">
+        <div class="gf-form">
+          <label class="gf-form-label query-keyword width-7">AGG</label>
+          <metric-segment segment="ctrl.aggregationSegment" get-options="ctrl.getAggregations()" on-change="ctrl.aggregationChanged()"></metric-segment>
+        </div>
+        <div class="gf-form-inline">
+          <label class="gf-form-label query-keyword width-7">METRIC</label>
+          <div class="gf-form max-width-30">
+            <input type="text" class="gf-form-input" ng-model="ctrl.metricKeyword" spellcheck='false' placeholder="Type keyword here">
+          </div>
+          <div ng-if="ctrl.metricKeyword">
+            <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
+          </div>
+        </div>
+        <div class="gf-form">
+          <label class="gf-form-label query-keyword width-7">POST</label>
+          <metric-segment segment="ctrl.asSegment" get-options="ctrl.getAs()" on-change="ctrl.asChanged()"></metric-segment>
+        </div>
+  
+        <div class="gf-form gf-form--grow">
+          <div class="gf-form-label gf-form-label--grow"></div> 
+        </div>
       </div>
-      <div class="gf-form" ng-repeat="segment in ctrl.tagSegments">
-        <metric-segment segment="segment" get-options="ctrl.getTags(segment, $index)" on-change="ctrl.tagSegmentUpdated(segment, $index)"></metric-segment>
+  
+      <div class="gf-form-inline">
+        <div class="gf-form">
+          <label class="gf-form-label query-keyword width-7">SCOPE</label>
+        </div>
+        <div class="gf-form" ng-repeat="segment in ctrl.tagSegments">
+          <metric-segment segment="segment" get-options="ctrl.getTags(segment, $index)" on-change="ctrl.tagSegmentUpdated(segment, $index)"></metric-segment>
+        </div>
+  
+        <div class="gf-form gf-form--grow">
+          <div class="gf-form-label gf-form-label--grow"></div>
+        </div>
       </div>
-
-      <div class="gf-form gf-form--grow">
-        <div class="gf-form-label gf-form-label--grow"></div>
+  
+      <div class="gf-form-inline">
+        <div class="gf-form">
+          <label class="gf-form-label query-keyword width-7">FUNCS</label>
+        </div>
+  
+        <div ng-repeat="func in ctrl.functions" class="gf-form">
+          <span datadog-func-editor class="gf-form-label query-part"></span>
+        </div>
+        <div class="gf-form dropdown">
+          <span datadog-add-func></span>
+        </div>
+  
+        <div class="gf-form gf-form--grow">
+          <div class="gf-form-label gf-form-label--grow"></div>
+        </div>
+  
       </div>
+  
+      <div class="gf-form-inline">
+        <div class="gf-form max-width-30">
+          <label class="gf-form-label query-keyword width-7">GROUP BY</label>
+          <input type="text" class="gf-form-input" ng-model="ctrl.target.groups" spellcheck='false' placeholder="Tags (separate by comma)" ng-blur="ctrl.refresh()">
+        </div>
+  
+        <div class="gf-form gf-form--grow">
+          <div class="gf-form-label gf-form-label--grow"></div>
+        </div>
+      </div>
+  
+      <div class="gf-form-inline">
+        <div class="gf-form max-width-30">
+          <label class="gf-form-label query-keyword width-7">ALIAS BY</label>
+          <input type="text" class="gf-form-input" ng-model="ctrl.target.alias" spellcheck='false' placeholder="Naming pattern" ng-blur="ctrl.refresh()">
+        </div>
+  
+        <div class="gf-form gf-form--grow">
+          <div class="gf-form-label gf-form-label--grow"></div>
+        </div>
+      </div>
+  
     </div>
-
-    <div class="gf-form-inline">
-      <div class="gf-form">
-        <label class="gf-form-label query-keyword width-7">FUNCS</label>
-      </div>
-
-      <div ng-repeat="func in ctrl.functions" class="gf-form">
-        <span datadog-func-editor class="gf-form-label query-part"></span>
-      </div>
-      <div class="gf-form dropdown">
-        <span datadog-add-func></span>
-      </div>
-
-      <div class="gf-form gf-form--grow">
-        <div class="gf-form-label gf-form-label--grow"></div>
-      </div>
-
-    </div>
-
-    <div class="gf-form-inline">
-      <div class="gf-form max-width-30">
-        <label class="gf-form-label query-keyword width-7">GROUP BY</label>
-        <input type="text" class="gf-form-input" ng-model="ctrl.target.groups" spellcheck='false' placeholder="Tags (separate by comma)" ng-blur="ctrl.refresh()">
-      </div>
-
-      <div class="gf-form gf-form--grow">
-        <div class="gf-form-label gf-form-label--grow"></div>
-      </div>
-    </div>
-
-    <div class="gf-form-inline">
-      <div class="gf-form max-width-30">
-        <label class="gf-form-label query-keyword width-7">ALIAS BY</label>
-        <input type="text" class="gf-form-input" ng-model="ctrl.target.alias" spellcheck='false' placeholder="Naming pattern" ng-blur="ctrl.refresh()">
-      </div>
-
-      <div class="gf-form gf-form--grow">
-        <div class="gf-form-label gf-form-label--grow"></div>
-      </div>
-    </div>
-
-  </div>
-
-</query-editor-row>
+  
+  </query-editor-row>

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -14,11 +14,9 @@
         <div class="gf-form-inline">
           <label class="gf-form-label query-keyword width-7">METRIC</label>
           <div class="gf-form max-width-30">
-            <input type="text" class="gf-form-input" ng-model="ctrl.metricKeyword" spellcheck='false' placeholder="Type keyword here">
+            <input type="text" class="gf-form-input width-15" ng-model="ctrl.metricKeyword" spellcheck='false' placeholder="Type your keyword here">
           </div>
-          <div ng-if="ctrl.metricKeyword">
-            <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
-          </div>
+          <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
         </div>
         <div class="gf-form">
           <label class="gf-form-label query-keyword width-7">POST</label>

--- a/src/query_builder.js
+++ b/src/query_builder.js
@@ -1,97 +1,424 @@
 'use strict';
 
-System.register(['lodash', './dfunc'], function (_export, _context) {
+System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add_datadog_func', './query_builder'], function (_export, _context) {
   "use strict";
 
-  var _, dfunc;
+  var _, dfunc, QueryCtrl, queryBuilder, _createClass, DataDogQueryCtrl;
 
-  function buildQuery(target, adhocFilters) {
-    var aggregation = target.aggregation,
-        metric = target.metric,
-        tags = target.tags,
-        functions = target.functions;
-
-    var query = aggregation + ':' + metric;
-
-    var functionInstances = getFunctionInstances(functions);
-
-    if (tags && tags.length || adhocFilters && adhocFilters.length) {
-      query += '{';
-
-      if (tags && tags.length) {
-        query += tags.join(',');
-      }
-
-      if (adhocFilters && adhocFilters.length) {
-        var adhocTags = buildAdHocFilterString(adhocFilters);
-        if (tags && tags.length) {
-          query += ',';
-        }
-        query += adhocTags;
-      }
-
-      query += '}';
-    } else {
-      query += '{*}';
+  function _classCallCheck(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+      throw new TypeError("Cannot call a class as a function");
     }
-
-    if (target.groups) {
-      var groups = target.groups.split(",");
-      query += ' by {';
-      for (var i = 0; i < groups.length; ++i) {
-        query += groups[i];
-        if (i !== groups.length - 1) {
-          query += ',';
-        }
-      }
-      query += '}';
-    }
-
-    if (target.as) {
-      query += '.' + target.as + '()';
-    }
-
-    var groupedFuncs = _.groupBy(functionInstances, function (func) {
-      if (func.def.append) {
-        return 'appends';
-      } else {
-        return 'wraps';
-      }
-    });
-
-    _.each(groupedFuncs.appends, function (func) {
-      query += '.' + func.render();
-    });
-
-    _.each(groupedFuncs.wraps, function (func) {
-      query = func.render(query);
-    });
-  
-    return query;
   }
 
-  _export('buildQuery', buildQuery);
+  function _possibleConstructorReturn(self, call) {
+    if (!self) {
+      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+    }
 
-  function getFunctionInstances(functions) {
-    return _.map(functions, function (func) {
-      var f = dfunc.createFuncInstance(func.funcDef, { withDefaultParams: false });
-      f.params = func.params.slice();
-      return f;
+    return call && (typeof call === "object" || typeof call === "function") ? call : self;
+  }
+
+  function _inherits(subClass, superClass) {
+    if (typeof superClass !== "function" && superClass !== null) {
+      throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+    }
+
+    subClass.prototype = Object.create(superClass && superClass.prototype, {
+      constructor: {
+        value: subClass,
+        enumerable: false,
+        writable: true,
+        configurable: true
+      }
     });
+    if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
   }
 
-  function buildAdHocFilterString(adhocFilters) {
-    return adhocFilters.map(function (filter) {
-      return filter.key + ':' + filter.value;
-    }).join(',');
-  }
   return {
     setters: [function (_lodash) {
       _ = _lodash.default;
     }, function (_dfunc) {
       dfunc = _dfunc.default;
+    }, function (_appPluginsSdk) {
+      QueryCtrl = _appPluginsSdk.QueryCtrl;
+    }, function (_func_editor) {}, function (_add_datadog_func) {}, function (_query_builder) {
+      queryBuilder = _query_builder;
     }],
-    execute: function () {}
+    execute: function () {
+      _createClass = function () {
+        function defineProperties(target, props) {
+          for (var i = 0; i < props.length; i++) {
+            var descriptor = props[i];
+            descriptor.enumerable = descriptor.enumerable || false;
+            descriptor.configurable = true;
+            if ("value" in descriptor) descriptor.writable = true;
+            Object.defineProperty(target, descriptor.key, descriptor);
+          }
+        }
+
+        return function (Constructor, protoProps, staticProps) {
+          if (protoProps) defineProperties(Constructor.prototype, protoProps);
+          if (staticProps) defineProperties(Constructor, staticProps);
+          return Constructor;
+        };
+      }();
+
+      _export('DataDogQueryCtrl', DataDogQueryCtrl = function (_QueryCtrl) {
+        _inherits(DataDogQueryCtrl, _QueryCtrl);
+
+        function DataDogQueryCtrl($scope, $injector, uiSegmentSrv, templateSrv) {
+          _classCallCheck(this, DataDogQueryCtrl);
+
+          var _this = _possibleConstructorReturn(this, (DataDogQueryCtrl.__proto__ || Object.getPrototypeOf(DataDogQueryCtrl)).call(this, $scope, $injector));
+
+          _this.removeText = '-- remove tag --';
+          _this.uiSegmentSrv = uiSegmentSrv;
+          _this.templateSrv = templateSrv;
+
+          if (_this.target.aggregation) {
+            _this.aggregationSegment = new uiSegmentSrv.newSegment(_this.target.aggregation);
+          } else {
+            _this.aggregationSegment = new uiSegmentSrv.newSegment({
+              value: 'Select Aggregation',
+              fake: true,
+              custom: false
+            });
+          }
+
+          if (_this.target.metric) {
+            _this.metricSegment = new uiSegmentSrv.newSegment(_this.target.metric);
+          } else {
+            _this.metricSegment = new uiSegmentSrv.newSelectMetric();
+          }
+
+          _this.target.tags = _this.target.tags || [];
+          _this.tagSegments = _this.target.tags.map(uiSegmentSrv.newSegment);
+          _this.fixTagSegments();
+
+          _this.functions = [];
+          _this.target.functions = _this.target.functions || [];
+          _this.functions = _.map(_this.target.functions, function (func) {
+            var f = dfunc.createFuncInstance(func.funcDef, { withDefaultParams: false });
+            f.params = func.params.slice();
+            return f;
+          });
+
+          if (_this.target.as) {
+            _this.asSegment = uiSegmentSrv.newSegment(_this.target.as);
+          } else {
+            _this.asSegment = uiSegmentSrv.newSegment({
+              value: 'Select As',
+              fake: true,
+              custom: false
+            });
+          }
+
+          return _this;
+        }
+
+        _createClass(DataDogQueryCtrl, [{
+          key: 'toggleEditorMode',
+          value: function toggleEditorMode() {
+            this.target.rawQuery = !this.target.rawQuery;
+            if (this.target.rawQuery) {
+              this.target.query = queryBuilder.buildQuery(this.target);
+            } else {
+              if (this.target.query !== 'undefined:undefined{*}') {
+                this.parseQuery();
+              } else {
+                this.refreshOptions();
+              }
+            }
+              
+          }
+        }, {
+          key: 'refreshOptions',
+          value: function refreshOptions() {
+            delete this.target.metric;
+            delete this.target.aggregation;
+            delete this.target.as;
+            this.asSegment = this.uiSegmentSrv.newSegment({
+              value: 'Select As',
+              fake: true,
+              custom: false
+            });
+
+            this.aggregationSegment = this.uiSegmentSrv.newSegment({
+              value: 'Select Aggregation',
+              fake: true,
+              custom: false
+            });
+
+            this.metricSegment = this.uiSegmentSrv.newSelectMetric();
+
+            this.targetChanged();
+          }
+        }, {
+          key: 'getCollapsedText',
+          value: function getCollapsedText() {
+            if (this.target.rawQuery) {
+              return this.target.query;
+            } else {
+              return queryBuilder.buildQuery(this.target);
+            }
+          }
+        }, {
+          key: 'checkQuery',
+          value: function checkQuery() {
+            if (!(this.target.query || this.target.query.length != 0)) 
+            // to avoid 400 Bad Request, this is the default query
+              this.target.query = 'undefined:undefined{*}';
+            this.panelCtrl.refresh();
+          }
+        }, {
+          key: 'parseQuery',
+          value: function parseQuery() {
+            
+            var stack = [];
+            var query = this.target.query;
+            var tmpString = [];
+
+            if (query.indexOf('(') === -1) {
+              stack.push(query);
+            }
+
+            for (var i = 0; i < query.length; ++i) {
+              if (query[i] !== '(' && query[i] !== ')') {
+                tmpString.push(query[i]);
+              } else {
+                stack.push(tmpString.join(''));
+                tmpString = [];
+              }
+            } 
+
+            var functions = [];
+            var scopes = [];
+            var metricCollected = false;
+            var aggregation, metric, as, groups = null;
+
+            for (var component of stack) {
+              // check if it is a function
+              if (!component.includes(':') && !metricCollected) {
+                functions.push({
+                  name: component,
+                  defaultParams: []
+                });
+              } else {
+                /*
+                here it could have a metric, a scope
+                example: avg:aws.autoscaling.group_in_service_instances{*} by {name,team}.as_count()
+                and it should be the last component
+                */
+                var aggrIndex = component.indexOf(':');
+                aggregation = component.slice(0, aggrIndex);
+                aggregation = aggregation == 'undefined' ? null : aggregation;
+
+                // process metric
+                var withNoAggr = component.slice(aggrIndex + 1);
+                var metricEnd = withNoAggr.indexOf('{');
+                metric = withNoAggr.slice(0, metricEnd);
+                metric = metric == 'undefined' ? null : metric;
+                metricCollected = true;
+
+                // process scopes
+                var withNoMetric = withNoAggr.slice(metricEnd + 1);
+                var scopeEnd = withNoMetric.indexOf('}');
+                scopes = withNoMetric.slice(0, scopeEnd).trim().split(',');
+
+                // process groups
+                var withNoScopes = withNoMetric.slice(scopeEnd + 1);
+                var groupStart = withNoScopes.indexOf('{');
+                if (groupStart !== -1) {
+                  // there are groups
+                  var groupEnd = withNoScopes.indexOf('}');
+                  groups = withNoScopes.slice(groupStart + 1, groupEnd);
+                } 
+
+                // process as
+                var asStart = withNoScopes.indexOf('.');
+                if (asStart !== -1) {
+                  as = withNoScopes.slice(asStart + 1);
+                } 
+                
+                // reconstruct segments
+                if (aggregation) {
+                  this.target.aggregation = aggregation;
+                  this.aggregationSegment = this.uiSegmentSrv.newSegment(aggregation);
+                } 
+
+                if (metric) {
+                  this.target.metric = metric;
+                  this.metricSegment = this.uiSegmentSrv.newSegment({
+                    value: metric,
+                    fake: true
+                  });
+                } 
+                
+                if (as) {
+                  this.target.as = as;
+                  this.asSegment = this.uiSegmentSrv.newSegment(as);
+                } else {
+                  delete this.target.as;
+                  this.asSegment = this.uiSegmentSrv.newSegment({
+                    value: 'Select As',
+                    fake: true,
+                    custom: false
+                  });
+                }
+
+                // sammple query with tags/scopes: 
+                if (scopes.length > 0 && scopes[0] !== '') {
+                  this.target.tags = [];
+                  for (var scope of scopes) {
+                    if (scope !== '*') {
+                      this.target.tags.push(scope);
+                    }
+                  }
+                  this.tagSegments = _.map(this.target.tags, this.uiSegmentSrv.newSegment);
+                  this.fixTagSegments();
+                }
+
+                // sample query with functions
+                if (functions.length > 0) {
+                  this.target.functions = [];
+                  this.functions = [];
+                  for (var func of functions) {
+                    this.addFunction(func);
+                  }
+                }
+
+                if (groups && groups.length > 0) {
+                  this.target.groups = groups;
+                } else {
+                  delete this.target.groups;
+                }
+                this.targetChanged();
+              }
+            }
+          }
+        }, {
+          key: 'getMetrics',
+          value: function getMetrics() {
+            if (this.metricKeyword && this.metricKeyword.length > 0) {
+              return this.datasource.initMetricsFetching(this.metricKeyword).then(this.uiSegmentSrv.transformToSegments(true));
+            }
+          }
+        }, {
+          key: 'getAggregations',
+          value: function getAggregations() {
+            return Promise.resolve([{ text: 'avg by', value: 'avg' }, { text: 'max by', value: 'max' }, { text: 'min by', value: 'min' }, { text: 'sub by', value: 'sum' }]);
+          }
+        }, {
+          key: 'getAs',
+          value: function getAs() {
+            return Promise.resolve([{ text: 'None', value: 'None' }, { text: 'as_count', value: 'as_count' }, { text: 'as_rate', value: 'as_rate' }]);
+          }
+        }, {
+          key: 'getTags',
+          value: function getTags(segment) {
+            var _this2 = this;
+
+            return this.datasource.tagFindQuery().then(this.uiSegmentSrv.transformToSegments(true)).then(function (results) {
+              if (segment.type !== 'plus-button') {
+                var removeSegment = _this2.uiSegmentSrv.newFake(_this2.removeText);
+                results.unshift(removeSegment);
+              }
+
+              return results;
+            });
+          }
+        }, {
+          key: 'aggregationChanged',
+          value: function aggregationChanged() {
+            this.target.aggregation = this.aggregationSegment.value;
+            this.panelCtrl.refresh();
+          }
+        }, {
+          key: 'metricChanged',
+          value: function metricChanged() {
+            this.target.metric = this.metricSegment.value;
+            this.panelCtrl.refresh();
+          }
+        }, {
+          key: 'asChanged',
+          value: function asChanged() {
+            this.target.as = this.asSegment.value;
+            this.panelCtrl.refresh();
+          }
+        }, {
+          key: 'fixTagSegments',
+          value: function fixTagSegments() {
+            var count = this.tagSegments.length;
+            var lastSegment = this.tagSegments[Math.max(count - 1, 0)];
+
+            if (!lastSegment || lastSegment.type !== 'plus-button') {
+              this.tagSegments.push(this.uiSegmentSrv.newPlusButton());
+            }
+          }
+        }, {
+          key: 'targetChanged',
+          value: function targetChanged() {
+            if (this.error) {
+              return;
+            }
+
+            this.panelCtrl.refresh();
+          }
+        }, {
+          key: 'persistFunctions',
+          value: function persistFunctions() {
+            this.target.functions = _.map(this.functions, function (func) {
+              return {
+                funcDef: func.def.name,
+                params: func.params.slice()
+              };
+            });
+          }
+        }, {
+          key: 'removeFunction',
+          value: function removeFunction(func) {
+            this.functions = _.without(this.functions, func);
+            this.persistFunctions();
+            this.targetChanged();
+          }
+        }, {
+          key: 'addFunction',
+          value: function addFunction(funcDef) {
+            var func = dfunc.createFuncInstance(funcDef, { withDefaultParams: true });
+            func.added = true;
+            this.functions.push(func);
+            this.persistFunctions();
+            this.targetChanged();
+          }
+        }, {
+          key: 'tagSegmentUpdated',
+          value: function tagSegmentUpdated(segment, index) {
+            if (segment.value === this.removeText) {
+              this.tagSegments.splice(index, 1);
+            }
+
+            var realSegments = _.filter(this.tagSegments, function (segment) {
+              return segment.value;
+            });
+            this.target.tags = realSegments.map(function (segment) {
+              return segment.value;
+            });
+
+            this.tagSegments = _.map(this.target.tags, this.uiSegmentSrv.newSegment);
+            this.fixTagSegments();
+
+            this.panelCtrl.refresh();
+          }
+        }]);
+
+        return DataDogQueryCtrl;
+      }(QueryCtrl));
+
+      _export('DataDogQueryCtrl', DataDogQueryCtrl);
+
+      DataDogQueryCtrl.templateUrl = 'partials/query.editor.html';
+    }
   };
 });
-//# sourceMappingURL=query_builder.js.map
+//# sourceMappingURL=query_ctrl.js.map

--- a/src/query_builder.js
+++ b/src/query_builder.js
@@ -1,424 +1,97 @@
 'use strict';
 
-System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add_datadog_func', './query_builder'], function (_export, _context) {
+System.register(['lodash', './dfunc'], function (_export, _context) {
   "use strict";
 
-  var _, dfunc, QueryCtrl, queryBuilder, _createClass, DataDogQueryCtrl;
+  var _, dfunc;
 
-  function _classCallCheck(instance, Constructor) {
-    if (!(instance instanceof Constructor)) {
-      throw new TypeError("Cannot call a class as a function");
+  function buildQuery(target, adhocFilters) {
+    var aggregation = target.aggregation,
+        metric = target.metric,
+        tags = target.tags,
+        functions = target.functions;
+
+    var query = aggregation + ':' + metric;
+
+    var functionInstances = getFunctionInstances(functions);
+
+    if (tags && tags.length || adhocFilters && adhocFilters.length) {
+      query += '{';
+
+      if (tags && tags.length) {
+        query += tags.join(',');
+      }
+
+      if (adhocFilters && adhocFilters.length) {
+        var adhocTags = buildAdHocFilterString(adhocFilters);
+        if (tags && tags.length) {
+          query += ',';
+        }
+        query += adhocTags;
+      }
+
+      query += '}';
+    } else {
+      query += '{*}';
     }
-  }
 
-  function _possibleConstructorReturn(self, call) {
-    if (!self) {
-      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+    if (target.groups) {
+      var groups = target.groups.split(",");
+      query += ' by {';
+      for (var i = 0; i < groups.length; ++i) {
+        query += groups[i];
+        if (i !== groups.length - 1) {
+          query += ',';
+        }
+      }
+      query += '}';
     }
 
-    return call && (typeof call === "object" || typeof call === "function") ? call : self;
-  }
-
-  function _inherits(subClass, superClass) {
-    if (typeof superClass !== "function" && superClass !== null) {
-      throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+    if (target.as) {
+      query += '.' + target.as + '()';
     }
 
-    subClass.prototype = Object.create(superClass && superClass.prototype, {
-      constructor: {
-        value: subClass,
-        enumerable: false,
-        writable: true,
-        configurable: true
+    var groupedFuncs = _.groupBy(functionInstances, function (func) {
+      if (func.def.append) {
+        return 'appends';
+      } else {
+        return 'wraps';
       }
     });
-    if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+
+    _.each(groupedFuncs.appends, function (func) {
+      query += '.' + func.render();
+    });
+
+    _.each(groupedFuncs.wraps, function (func) {
+      query = func.render(query);
+    });
+  
+    return query;
   }
 
+  _export('buildQuery', buildQuery);
+
+  function getFunctionInstances(functions) {
+    return _.map(functions, function (func) {
+      var f = dfunc.createFuncInstance(func.funcDef, { withDefaultParams: false });
+      f.params = func.params.slice();
+      return f;
+    });
+  }
+
+  function buildAdHocFilterString(adhocFilters) {
+    return adhocFilters.map(function (filter) {
+      return filter.key + ':' + filter.value;
+    }).join(',');
+  }
   return {
     setters: [function (_lodash) {
       _ = _lodash.default;
     }, function (_dfunc) {
       dfunc = _dfunc.default;
-    }, function (_appPluginsSdk) {
-      QueryCtrl = _appPluginsSdk.QueryCtrl;
-    }, function (_func_editor) {}, function (_add_datadog_func) {}, function (_query_builder) {
-      queryBuilder = _query_builder;
     }],
-    execute: function () {
-      _createClass = function () {
-        function defineProperties(target, props) {
-          for (var i = 0; i < props.length; i++) {
-            var descriptor = props[i];
-            descriptor.enumerable = descriptor.enumerable || false;
-            descriptor.configurable = true;
-            if ("value" in descriptor) descriptor.writable = true;
-            Object.defineProperty(target, descriptor.key, descriptor);
-          }
-        }
-
-        return function (Constructor, protoProps, staticProps) {
-          if (protoProps) defineProperties(Constructor.prototype, protoProps);
-          if (staticProps) defineProperties(Constructor, staticProps);
-          return Constructor;
-        };
-      }();
-
-      _export('DataDogQueryCtrl', DataDogQueryCtrl = function (_QueryCtrl) {
-        _inherits(DataDogQueryCtrl, _QueryCtrl);
-
-        function DataDogQueryCtrl($scope, $injector, uiSegmentSrv, templateSrv) {
-          _classCallCheck(this, DataDogQueryCtrl);
-
-          var _this = _possibleConstructorReturn(this, (DataDogQueryCtrl.__proto__ || Object.getPrototypeOf(DataDogQueryCtrl)).call(this, $scope, $injector));
-
-          _this.removeText = '-- remove tag --';
-          _this.uiSegmentSrv = uiSegmentSrv;
-          _this.templateSrv = templateSrv;
-
-          if (_this.target.aggregation) {
-            _this.aggregationSegment = new uiSegmentSrv.newSegment(_this.target.aggregation);
-          } else {
-            _this.aggregationSegment = new uiSegmentSrv.newSegment({
-              value: 'Select Aggregation',
-              fake: true,
-              custom: false
-            });
-          }
-
-          if (_this.target.metric) {
-            _this.metricSegment = new uiSegmentSrv.newSegment(_this.target.metric);
-          } else {
-            _this.metricSegment = new uiSegmentSrv.newSelectMetric();
-          }
-
-          _this.target.tags = _this.target.tags || [];
-          _this.tagSegments = _this.target.tags.map(uiSegmentSrv.newSegment);
-          _this.fixTagSegments();
-
-          _this.functions = [];
-          _this.target.functions = _this.target.functions || [];
-          _this.functions = _.map(_this.target.functions, function (func) {
-            var f = dfunc.createFuncInstance(func.funcDef, { withDefaultParams: false });
-            f.params = func.params.slice();
-            return f;
-          });
-
-          if (_this.target.as) {
-            _this.asSegment = uiSegmentSrv.newSegment(_this.target.as);
-          } else {
-            _this.asSegment = uiSegmentSrv.newSegment({
-              value: 'Select As',
-              fake: true,
-              custom: false
-            });
-          }
-
-          return _this;
-        }
-
-        _createClass(DataDogQueryCtrl, [{
-          key: 'toggleEditorMode',
-          value: function toggleEditorMode() {
-            this.target.rawQuery = !this.target.rawQuery;
-            if (this.target.rawQuery) {
-              this.target.query = queryBuilder.buildQuery(this.target);
-            } else {
-              if (this.target.query !== 'undefined:undefined{*}') {
-                this.parseQuery();
-              } else {
-                this.refreshOptions();
-              }
-            }
-              
-          }
-        }, {
-          key: 'refreshOptions',
-          value: function refreshOptions() {
-            delete this.target.metric;
-            delete this.target.aggregation;
-            delete this.target.as;
-            this.asSegment = this.uiSegmentSrv.newSegment({
-              value: 'Select As',
-              fake: true,
-              custom: false
-            });
-
-            this.aggregationSegment = this.uiSegmentSrv.newSegment({
-              value: 'Select Aggregation',
-              fake: true,
-              custom: false
-            });
-
-            this.metricSegment = this.uiSegmentSrv.newSelectMetric();
-
-            this.targetChanged();
-          }
-        }, {
-          key: 'getCollapsedText',
-          value: function getCollapsedText() {
-            if (this.target.rawQuery) {
-              return this.target.query;
-            } else {
-              return queryBuilder.buildQuery(this.target);
-            }
-          }
-        }, {
-          key: 'checkQuery',
-          value: function checkQuery() {
-            if (!(this.target.query || this.target.query.length != 0)) 
-            // to avoid 400 Bad Request, this is the default query
-              this.target.query = 'undefined:undefined{*}';
-            this.panelCtrl.refresh();
-          }
-        }, {
-          key: 'parseQuery',
-          value: function parseQuery() {
-            
-            var stack = [];
-            var query = this.target.query;
-            var tmpString = [];
-
-            if (query.indexOf('(') === -1) {
-              stack.push(query);
-            }
-
-            for (var i = 0; i < query.length; ++i) {
-              if (query[i] !== '(' && query[i] !== ')') {
-                tmpString.push(query[i]);
-              } else {
-                stack.push(tmpString.join(''));
-                tmpString = [];
-              }
-            } 
-
-            var functions = [];
-            var scopes = [];
-            var metricCollected = false;
-            var aggregation, metric, as, groups = null;
-
-            for (var component of stack) {
-              // check if it is a function
-              if (!component.includes(':') && !metricCollected) {
-                functions.push({
-                  name: component,
-                  defaultParams: []
-                });
-              } else {
-                /*
-                here it could have a metric, a scope
-                example: avg:aws.autoscaling.group_in_service_instances{*} by {name,team}.as_count()
-                and it should be the last component
-                */
-                var aggrIndex = component.indexOf(':');
-                aggregation = component.slice(0, aggrIndex);
-                aggregation = aggregation == 'undefined' ? null : aggregation;
-
-                // process metric
-                var withNoAggr = component.slice(aggrIndex + 1);
-                var metricEnd = withNoAggr.indexOf('{');
-                metric = withNoAggr.slice(0, metricEnd);
-                metric = metric == 'undefined' ? null : metric;
-                metricCollected = true;
-
-                // process scopes
-                var withNoMetric = withNoAggr.slice(metricEnd + 1);
-                var scopeEnd = withNoMetric.indexOf('}');
-                scopes = withNoMetric.slice(0, scopeEnd).trim().split(',');
-
-                // process groups
-                var withNoScopes = withNoMetric.slice(scopeEnd + 1);
-                var groupStart = withNoScopes.indexOf('{');
-                if (groupStart !== -1) {
-                  // there are groups
-                  var groupEnd = withNoScopes.indexOf('}');
-                  groups = withNoScopes.slice(groupStart + 1, groupEnd);
-                } 
-
-                // process as
-                var asStart = withNoScopes.indexOf('.');
-                if (asStart !== -1) {
-                  as = withNoScopes.slice(asStart + 1);
-                } 
-                
-                // reconstruct segments
-                if (aggregation) {
-                  this.target.aggregation = aggregation;
-                  this.aggregationSegment = this.uiSegmentSrv.newSegment(aggregation);
-                } 
-
-                if (metric) {
-                  this.target.metric = metric;
-                  this.metricSegment = this.uiSegmentSrv.newSegment({
-                    value: metric,
-                    fake: true
-                  });
-                } 
-                
-                if (as) {
-                  this.target.as = as;
-                  this.asSegment = this.uiSegmentSrv.newSegment(as);
-                } else {
-                  delete this.target.as;
-                  this.asSegment = this.uiSegmentSrv.newSegment({
-                    value: 'Select As',
-                    fake: true,
-                    custom: false
-                  });
-                }
-
-                // sammple query with tags/scopes: 
-                if (scopes.length > 0 && scopes[0] !== '') {
-                  this.target.tags = [];
-                  for (var scope of scopes) {
-                    if (scope !== '*') {
-                      this.target.tags.push(scope);
-                    }
-                  }
-                  this.tagSegments = _.map(this.target.tags, this.uiSegmentSrv.newSegment);
-                  this.fixTagSegments();
-                }
-
-                // sample query with functions
-                if (functions.length > 0) {
-                  this.target.functions = [];
-                  this.functions = [];
-                  for (var func of functions) {
-                    this.addFunction(func);
-                  }
-                }
-
-                if (groups && groups.length > 0) {
-                  this.target.groups = groups;
-                } else {
-                  delete this.target.groups;
-                }
-                this.targetChanged();
-              }
-            }
-          }
-        }, {
-          key: 'getMetrics',
-          value: function getMetrics() {
-            if (this.metricKeyword && this.metricKeyword.length > 0) {
-              return this.datasource.initMetricsFetching(this.metricKeyword).then(this.uiSegmentSrv.transformToSegments(true));
-            }
-          }
-        }, {
-          key: 'getAggregations',
-          value: function getAggregations() {
-            return Promise.resolve([{ text: 'avg by', value: 'avg' }, { text: 'max by', value: 'max' }, { text: 'min by', value: 'min' }, { text: 'sub by', value: 'sum' }]);
-          }
-        }, {
-          key: 'getAs',
-          value: function getAs() {
-            return Promise.resolve([{ text: 'None', value: 'None' }, { text: 'as_count', value: 'as_count' }, { text: 'as_rate', value: 'as_rate' }]);
-          }
-        }, {
-          key: 'getTags',
-          value: function getTags(segment) {
-            var _this2 = this;
-
-            return this.datasource.tagFindQuery().then(this.uiSegmentSrv.transformToSegments(true)).then(function (results) {
-              if (segment.type !== 'plus-button') {
-                var removeSegment = _this2.uiSegmentSrv.newFake(_this2.removeText);
-                results.unshift(removeSegment);
-              }
-
-              return results;
-            });
-          }
-        }, {
-          key: 'aggregationChanged',
-          value: function aggregationChanged() {
-            this.target.aggregation = this.aggregationSegment.value;
-            this.panelCtrl.refresh();
-          }
-        }, {
-          key: 'metricChanged',
-          value: function metricChanged() {
-            this.target.metric = this.metricSegment.value;
-            this.panelCtrl.refresh();
-          }
-        }, {
-          key: 'asChanged',
-          value: function asChanged() {
-            this.target.as = this.asSegment.value;
-            this.panelCtrl.refresh();
-          }
-        }, {
-          key: 'fixTagSegments',
-          value: function fixTagSegments() {
-            var count = this.tagSegments.length;
-            var lastSegment = this.tagSegments[Math.max(count - 1, 0)];
-
-            if (!lastSegment || lastSegment.type !== 'plus-button') {
-              this.tagSegments.push(this.uiSegmentSrv.newPlusButton());
-            }
-          }
-        }, {
-          key: 'targetChanged',
-          value: function targetChanged() {
-            if (this.error) {
-              return;
-            }
-
-            this.panelCtrl.refresh();
-          }
-        }, {
-          key: 'persistFunctions',
-          value: function persistFunctions() {
-            this.target.functions = _.map(this.functions, function (func) {
-              return {
-                funcDef: func.def.name,
-                params: func.params.slice()
-              };
-            });
-          }
-        }, {
-          key: 'removeFunction',
-          value: function removeFunction(func) {
-            this.functions = _.without(this.functions, func);
-            this.persistFunctions();
-            this.targetChanged();
-          }
-        }, {
-          key: 'addFunction',
-          value: function addFunction(funcDef) {
-            var func = dfunc.createFuncInstance(funcDef, { withDefaultParams: true });
-            func.added = true;
-            this.functions.push(func);
-            this.persistFunctions();
-            this.targetChanged();
-          }
-        }, {
-          key: 'tagSegmentUpdated',
-          value: function tagSegmentUpdated(segment, index) {
-            if (segment.value === this.removeText) {
-              this.tagSegments.splice(index, 1);
-            }
-
-            var realSegments = _.filter(this.tagSegments, function (segment) {
-              return segment.value;
-            });
-            this.target.tags = realSegments.map(function (segment) {
-              return segment.value;
-            });
-
-            this.tagSegments = _.map(this.target.tags, this.uiSegmentSrv.newSegment);
-            this.fixTagSegments();
-
-            this.panelCtrl.refresh();
-          }
-        }]);
-
-        return DataDogQueryCtrl;
-      }(QueryCtrl));
-
-      _export('DataDogQueryCtrl', DataDogQueryCtrl);
-
-      DataDogQueryCtrl.templateUrl = 'partials/query.editor.html';
-    }
+    execute: function () {}
   };
 });
-//# sourceMappingURL=query_ctrl.js.map
+//# sourceMappingURL=query_builder.js.map

--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -300,9 +300,7 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
         }, {
           key: 'getMetrics',
           value: function getMetrics() {
-            if (this.metricKeyword && this.metricKeyword.length > 0) {
-              return this.datasource.initMetricsFetching(this.metricKeyword).then(this.uiSegmentSrv.transformToSegments(true));
-            }
+            return this.datasource.initMetricsFetching(this.metricKeyword).then(this.uiSegmentSrv.transformToSegments(true));
           }
         }, {
           key: 'getAggregations',

--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -89,11 +89,7 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
           if (_this.target.metric) {
             _this.metricSegment = new uiSegmentSrv.newSegment(_this.target.metric);
           } else {
-            _this.metricSegment = new uiSegmentSrv.newSegment({
-              value: 'Select Metric',
-              fake: true,
-              custom: false
-            });
+            _this.metricSegment = new uiSegmentSrv.newSelectMetric();
           }
 
           _this.target.tags = _this.target.tags || [];
@@ -125,8 +121,38 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
           key: 'toggleEditorMode',
           value: function toggleEditorMode() {
             this.target.rawQuery = !this.target.rawQuery;
-            if (this.target.rawQuery)
+            if (this.target.rawQuery) {
               this.target.query = queryBuilder.buildQuery(this.target);
+            } else {
+              if (this.target.query !== 'undefined:undefined{*}') {
+                this.parseQuery();
+              } else {
+                this.refreshOptions();
+              }
+            }
+              
+          }
+        }, {
+          key: 'refreshOptions',
+          value: function refreshOptions() {
+            delete this.target.metric;
+            delete this.target.aggregation;
+            delete this.target.as;
+            this.asSegment = this.uiSegmentSrv.newSegment({
+              value: 'Select As',
+              fake: true,
+              custom: false
+            });
+
+            this.aggregationSegment = this.uiSegmentSrv.newSegment({
+              value: 'Select Aggregation',
+              fake: true,
+              custom: false
+            });
+
+            this.metricSegment = this.uiSegmentSrv.newSelectMetric();
+
+            this.targetChanged();
           }
         }, {
           key: 'getCollapsedText',
@@ -146,9 +172,137 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
             this.panelCtrl.refresh();
           }
         }, {
+          key: 'parseQuery',
+          value: function parseQuery() {
+            
+            var stack = [];
+            var query = this.target.query;
+            var tmpString = [];
+
+            if (query.indexOf('(') === -1) {
+              stack.push(query);
+            }
+
+            for (var i = 0; i < query.length; ++i) {
+              if (query[i] !== '(' && query[i] !== ')') {
+                tmpString.push(query[i]);
+              } else {
+                stack.push(tmpString.join(''));
+                tmpString = [];
+              }
+            } 
+
+            var functions = [];
+            var scopes = [];
+            var metricCollected = false;
+            var aggregation, metric, as, groups = null;
+
+            for (var component of stack) {
+              // check if it is a function
+              if (!component.includes(':') && !metricCollected) {
+                functions.push({
+                  name: component,
+                  defaultParams: []
+                });
+              } else {
+                /*
+                here it could have a metric, a scope
+                example: avg:aws.autoscaling.group_in_service_instances{*} by {name,team}.as_count()
+                and it should be the last component
+                */
+                var aggrIndex = component.indexOf(':');
+                aggregation = component.slice(0, aggrIndex);
+                aggregation = aggregation == 'undefined' ? null : aggregation;
+
+                // process metric
+                var withNoAggr = component.slice(aggrIndex + 1);
+                var metricEnd = withNoAggr.indexOf('{');
+                metric = withNoAggr.slice(0, metricEnd);
+                metric = metric == 'undefined' ? null : metric;
+                metricCollected = true;
+
+                // process scopes
+                var withNoMetric = withNoAggr.slice(metricEnd + 1);
+                var scopeEnd = withNoMetric.indexOf('}');
+                scopes = withNoMetric.slice(0, scopeEnd).trim().split(',');
+
+                // process groups
+                var withNoScopes = withNoMetric.slice(scopeEnd + 1);
+                var groupStart = withNoScopes.indexOf('{');
+                if (groupStart !== -1) {
+                  // there are groups
+                  var groupEnd = withNoScopes.indexOf('}');
+                  groups = withNoScopes.slice(groupStart + 1, groupEnd);
+                } 
+
+                // process as
+                var asStart = withNoScopes.indexOf('.');
+                if (asStart !== -1) {
+                  as = withNoScopes.slice(asStart + 1);
+                } 
+                
+                // reconstruct segments
+                if (aggregation) {
+                  this.target.aggregation = aggregation;
+                  this.aggregationSegment = this.uiSegmentSrv.newSegment(aggregation);
+                } 
+
+                if (metric) {
+                  this.target.metric = metric;
+                  this.metricSegment = this.uiSegmentSrv.newSegment({
+                    value: metric,
+                    fake: true
+                  });
+                } 
+                
+                if (as) {
+                  this.target.as = as;
+                  this.asSegment = this.uiSegmentSrv.newSegment(as);
+                } else {
+                  delete this.target.as;
+                  this.asSegment = this.uiSegmentSrv.newSegment({
+                    value: 'Select As',
+                    fake: true,
+                    custom: false
+                  });
+                }
+
+                // sammple query with tags/scopes: 
+                if (scopes.length > 0 && scopes[0] !== '') {
+                  this.target.tags = [];
+                  for (var scope of scopes) {
+                    if (scope !== '*') {
+                      this.target.tags.push(scope);
+                    }
+                  }
+                  this.tagSegments = _.map(this.target.tags, this.uiSegmentSrv.newSegment);
+                  this.fixTagSegments();
+                }
+
+                // sample query with functions
+                if (functions.length > 0) {
+                  this.target.functions = [];
+                  this.functions = [];
+                  for (var func of functions) {
+                    this.addFunction(func);
+                  }
+                }
+
+                if (groups && groups.length > 0) {
+                  this.target.groups = groups;
+                } else {
+                  delete this.target.groups;
+                }
+                this.targetChanged();
+              }
+            }
+          }
+        }, {
           key: 'getMetrics',
           value: function getMetrics() {
-            return this.datasource.metricFindQuery().then(this.uiSegmentSrv.transformToSegments(true));
+            if (this.metricKeyword && this.metricKeyword.length > 0) {
+              return this.datasource.initMetricsFetching(this.metricKeyword).then(this.uiSegmentSrv.transformToSegments(true));
+            }
           }
         }, {
           key: 'getAggregations',


### PR DESCRIPTION
**Changes**
1. Added an input for user to provide metric keyword
2. Only caching and loading at most 100 metrics based on the keyword
3. Only caching and loading at most 100 metrics by default when no keyword is entered

**Note**

- To configure the metric, either type a keyword and click on `select metric`. It would fetch at most 100 relevant metrics; if no keyword is typed and `select metric` is clicked, it would fetch the first 100 metrics from Datadog. Then, the user could typeahead to further narrow the results. 

- If the desired metric does not appear in the list, the user could directly input the metric in the menu or in the query editor. 

_Thank Emmanuel for the motivation._