### PR TITLE
[SRE-476] Metric Optimization - Dropdown for Metric Prefixes

### DIFF
--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -214,7 +214,7 @@ System.register(['lodash', './showdown.min.js', './query_builder'], function (_e
                 return Promise.resolve([]);
               }
             }
-            this.prefixFindQuery();
+            this.fetchMetrics();
             if (this._cached_metrics[prefix]) {
               return this.__cached_metrics[prefix].then((metrics) => this.resolveMetrics(metrics));
             } else {

--- a/dist/partials/query.editor.html
+++ b/dist/partials/query.editor.html
@@ -13,9 +13,7 @@
       </div>
       <div class="gf-form-inline">
         <label class="gf-form-label query-keyword width-7">METRIC</label>
-        <div class="gf-form max-width-30">
-          <input type="text" class="gf-form-input width-15" ng-model="ctrl.metricKeyword" spellcheck='false' placeholder="Type your keyword here">
-        </div>
+        <metric-segment segment="ctrl.metricPrefixSegment" get-options="ctrl.getMetricPrefixes()" on-change="ctrl.prefixChanged()"></metric-segment>
         <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
       </div>
       <div class="gf-form">

--- a/dist/query_ctrl.js
+++ b/dist/query_ctrl.js
@@ -309,12 +309,12 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
         }, {
           key: 'getMetrics',
           value: function getMetrics() {
-            return this.datasource.initMetricsFetching(this.metricPrefix).then(this.uiSegmentSrv.transformToSegments(true));
+            return this.datasource.fetchMetricsFromPrefix(this.metricPrefix).then(this.uiSegmentSrv.transformToSegments(true));
           }
         }, {
           key: 'getMetricPrefixes',
           value: function getMetricPrefixes() {
-            return this.datasource.prefixFindQuery().then(this.uiSegmentSrv.transformToSegments(true));
+            return this.datasource.fetchMetrics().then(this.uiSegmentSrv.transformToSegments(true));
           }
         }, {
           key: 'getAggregations',
@@ -358,7 +358,6 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
             // when the prefixes exist, metrics should have been already cached.
             // therefore could directly start filtering
             this.metricPrefix = this.metricPrefixSegment.value;
-            console.log('Prefix changed to : ' + this.metricPrefix + '\n');
           } 
         }, {
           key: 'asChanged',

--- a/dist/query_ctrl.js
+++ b/dist/query_ctrl.js
@@ -358,6 +358,7 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
             // when the prefixes exist, metrics should have been already cached.
             // therefore could directly start filtering
             this.metricPrefix = this.metricPrefixSegment.value;
+            this.panelCtrl.refresh();
           } 
         }, {
           key: 'asChanged',

--- a/dist/query_ctrl.js
+++ b/dist/query_ctrl.js
@@ -92,6 +92,15 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
             _this.metricSegment = new uiSegmentSrv.newSelectMetric();
           }
 
+          if (_this.metricPrefix) {
+            _this.metricPrefixSegment = new uiSegmentSrv.newSegment(_this.metricPrefix);
+          } else {
+            _this.metricPrefixSegment = new uiSegmentSrv.newSegment({
+              fake: true,
+              value: 'select metric prefix'
+            });
+          }
+
           _this.target.tags = _this.target.tags || [];
           _this.tagSegments = _this.target.tags.map(uiSegmentSrv.newSegment);
           _this.fixTagSegments();
@@ -300,7 +309,12 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
         }, {
           key: 'getMetrics',
           value: function getMetrics() {
-            return this.datasource.initMetricsFetching(this.metricKeyword).then(this.uiSegmentSrv.transformToSegments(true));
+            return this.datasource.initMetricsFetching(this.metricPrefix).then(this.uiSegmentSrv.transformToSegments(true));
+          }
+        }, {
+          key: 'getMetricPrefixes',
+          value: function getMetricPrefixes() {
+            return this.datasource.prefixFindQuery().then(this.uiSegmentSrv.transformToSegments(true));
           }
         }, {
           key: 'getAggregations',
@@ -338,6 +352,14 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
             this.target.metric = this.metricSegment.value;
             this.panelCtrl.refresh();
           }
+        }, {
+          key: 'prefixChanged',
+          value: function prefixChanged() {
+            // when the prefixes exist, metrics should have been already cached.
+            // therefore could directly start filtering
+            this.metricPrefix = this.metricPrefixSegment.value;
+            console.log('Prefix changed to : ' + this.metricPrefix + '\n');
+          } 
         }, {
           key: 'asChanged',
           value: function asChanged() {

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -111,8 +111,9 @@ System.register(['lodash', './showdown.min.js', './query_builder'], function (_e
           this.supportMetrics = true;
           this.backendSrv = backendSrv;
           this.templateSrv = templateSrv;
-          this._cached_metrics = false;
-          this._cached_metricKeyword = '';
+          this._cached_metrics = {};
+          this._cached_set_prefixes = new Set();
+          this._cached_list_prefixes = [];
         }
 
         // Function to check Datasource health
@@ -160,71 +161,78 @@ System.register(['lodash', './showdown.min.js', './query_builder'], function (_e
             return Math.floor(d.getTime() / 1000);
           }
         }, {
-          key: 'metricFindQuery',
-          value: function metricFindQuery(query) {
+          key: 'fetchMetrics',
+          value: function fetchMetrics() {
             var _this = this;
 
-            if (query === 'tag') {
-              return this.tagFindQuery();
+            if (this._cached_list_prefixes && this._cached_list_prefixes.length > 0) {
+              return Promise.resolve(this._cached_list_prefixes);
+            }
+
+            if (this.fetching_prefixes) {
+              return this.fetching_prefixes;
             }
 
 
-            if (this._cached_metrics) {
-              return Promise.resolve(this._cached_metrics);
-            }
-
-            if (this.fetching) {
-              return this.fetching;
-            }
-            
-            this.fetching = this.getMetrics().then(function (metrics) {
-              _this._cached_metrics = _.map(metrics, function (metric) {
-                return {
+            this.fetching_prefixes = this.getMetrics().then((metrics) => {
+              for (var metric of metrics) {
+                var prefix = String(metric.split('.')[0]);
+                if (!this._cached_set_prefixes.has(prefix)) {
+                  this._cached_set_prefixes.add(prefix);
+                  this._cached_list_prefixes.push({
+                    text: prefix,
+                    value: prefix
+                  });
+                }
+                
+                if (!this._cached_metrics[prefix]) {
+                  this._cached_metrics[prefix] = [];
+                }
+                this._cached_metrics[prefix].push({
                   text: metric,
                   value: metric
-                };
-              });
+                });
+              }
+              _this.cached_metrics = this._cached_metrics;
+              _this._cached_set_prefixes = this._cached_set_prefixes;
+              _this._cached_list_prefixes = this._cached_list_prefixes;
 
-              return _this._cached_metrics;
+              return _this._cached_list_prefixes;
             });
-
-            return this.fetching;
+            return this.fetching_prefixes;
           }
         }, {
-          key: 'initMetricsFetching',
-          value: function initMetricsFetching(keyword) {
-            var _this = this;
-            
-            if (keyword === this._cached_metricKeyword) {
-              if (this._cached_metrics) {
-                return Promise.resolve(this._cached_metrics);
+          key: 'fetchMetricsFromPrefix',
+          value: function fetchMetricsFromPrefix(prefix) {
+            if (!prefix || prefix.length === 0) {
+              return Promise.resolve([]);
+            }
+            if (this._cached_metrics) {
+              if (this._cached_metrics[prefix].length > 0) {
+                return Promise.resolve(this._cached_metrics[prefix]);
+              } else {
+                return Promise.resolve([]);
               }
-  
-              if (this.fetching) {
-                return this.fetching;
-              }  
             }
-
-            // if no keyword provided, fetch the first 100 metrics directly from Datadog
-            if (!keyword || keyword.length < 1) {
-              this.fetching = this.getMetrics().then((metrics) => this.resolveMetrics(metrics));
+            this.prefixFindQuery();
+            if (this._cached_metrics[prefix]) {
+              return this.__cached_metrics[prefix].then((metrics) => this.resolveMetrics(metrics));
             } else {
-              _this._cached_metricKeyword = keyword;
-              this.fetching = this.searchMetrics(keyword).then((metrics) => this.resolveMetrics(metrics));
+              return Promise.resolve([]);
             }
-            return this.fetching;
           }
         }, {
           key: 'resolveMetrics',
           value: function resolveMetrics(metrics) {
             var _this = this;
-            _this._cached_metrics = _.map(metrics, function (metric) {
+
+            _this._cached_relatedMetrics = _.map(metrics, function (metric) {
               return {
                 text: metric,
                 value: metric
               }
             });
-            return _this._cached_metrics;
+            return _this._cached_relatedMetrics;
           }
         }, {
           key: 'getTagKeys',
@@ -370,24 +378,10 @@ System.register(['lodash', './showdown.min.js', './query_builder'], function (_e
     
             return this.invokeDataDogApiRequest('/metrics', params).then(function (result) {
               if (result.metrics) {
-                return result.metrics.slice(0, 100);
+                return result.metrics;
               } else {
                 return [];
               }
-            });
-          }
-        }, {
-          key: 'searchMetrics',
-          value: function searchMetrics(keyword) {
-            if (keyword.length < 1 || !keyword) {
-              return [];
-            }
-
-            var params = {}
-            params.q = "metrics:" + keyword;
-
-            return this.invokeDataDogApiRequest('/search', params).then(function (response) {
-              return response.results.metrics ? response.results.metrics.slice(0, 100) : [];
             });
           }
         }, {

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -214,7 +214,7 @@ System.register(['lodash', './showdown.min.js', './query_builder'], function (_e
                 return Promise.resolve([]);
               }
             }
-            this.prefixFindQuery();
+            this.fetchMetrics();
             if (this._cached_metrics[prefix]) {
               return this.__cached_metrics[prefix].then((metrics) => this.resolveMetrics(metrics));
             } else {

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -1,86 +1,84 @@
 <query-editor-row query-ctrl="ctrl" has-text-edit-mode="true" can-collapse="true">
 
-    <div class="gf-form" ng-if="ctrl.target.rawQuery">
-      <input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" ng-blur="ctrl.checkQuery()"></input>
+  <div class="gf-form" ng-if="ctrl.target.rawQuery">
+    <input type="text" class="gf-form-input" ng-model="ctrl.target.query" spellcheck="false" ng-blur="ctrl.checkQuery()"></input>
+  </div>
+
+  <div ng-if="!ctrl.target.rawQuery">
+
+    <div class="gf-form-inline">
+      <div class="gf-form">
+        <label class="gf-form-label query-keyword width-7">AGG</label>
+        <metric-segment segment="ctrl.aggregationSegment" get-options="ctrl.getAggregations()" on-change="ctrl.aggregationChanged()"></metric-segment>
+      </div>
+      <div class="gf-form-inline">
+        <label class="gf-form-label query-keyword width-7">METRIC</label>
+        <metric-segment segment="ctrl.metricPrefixSegment" get-options="ctrl.getMetricPrefixes()" on-change="ctrl.prefixChanged()"></metric-segment>
+        <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
+      </div>
+      <div class="gf-form">
+        <label class="gf-form-label query-keyword width-7">POST</label>
+        <metric-segment segment="ctrl.asSegment" get-options="ctrl.getAs()" on-change="ctrl.asChanged()"></metric-segment>
+      </div>
+
+      <div class="gf-form gf-form--grow">
+        <div class="gf-form-label gf-form-label--grow"></div> 
+      </div>
     </div>
-  
-    <div ng-if="!ctrl.target.rawQuery">
-  
-      <div class="gf-form-inline">
-        <div class="gf-form">
-          <label class="gf-form-label query-keyword width-7">AGG</label>
-          <metric-segment segment="ctrl.aggregationSegment" get-options="ctrl.getAggregations()" on-change="ctrl.aggregationChanged()"></metric-segment>
-        </div>
-        <div class="gf-form-inline">
-          <label class="gf-form-label query-keyword width-7">METRIC</label>
-          <div class="gf-form max-width-30">
-            <input type="text" class="gf-form-input width-15" ng-model="ctrl.metricKeyword" spellcheck='false' placeholder="Type your keyword here">
-          </div>
-          <metric-segment segment="ctrl.metricSegment" get-options="ctrl.getMetrics()" on-change="ctrl.metricChanged()"></metric-segment>
-        </div>
-        <div class="gf-form">
-          <label class="gf-form-label query-keyword width-7">POST</label>
-          <metric-segment segment="ctrl.asSegment" get-options="ctrl.getAs()" on-change="ctrl.asChanged()"></metric-segment>
-        </div>
-  
-        <div class="gf-form gf-form--grow">
-          <div class="gf-form-label gf-form-label--grow"></div> 
-        </div>
+
+    <div class="gf-form-inline">
+      <div class="gf-form">
+        <label class="gf-form-label query-keyword width-7">SCOPE</label>
       </div>
-  
-      <div class="gf-form-inline">
-        <div class="gf-form">
-          <label class="gf-form-label query-keyword width-7">SCOPE</label>
-        </div>
-        <div class="gf-form" ng-repeat="segment in ctrl.tagSegments">
-          <metric-segment segment="segment" get-options="ctrl.getTags(segment, $index)" on-change="ctrl.tagSegmentUpdated(segment, $index)"></metric-segment>
-        </div>
-  
-        <div class="gf-form gf-form--grow">
-          <div class="gf-form-label gf-form-label--grow"></div>
-        </div>
+      <div class="gf-form" ng-repeat="segment in ctrl.tagSegments">
+        <metric-segment segment="segment" get-options="ctrl.getTags(segment, $index)" on-change="ctrl.tagSegmentUpdated(segment, $index)"></metric-segment>
       </div>
-  
-      <div class="gf-form-inline">
-        <div class="gf-form">
-          <label class="gf-form-label query-keyword width-7">FUNCS</label>
-        </div>
-  
-        <div ng-repeat="func in ctrl.functions" class="gf-form">
-          <span datadog-func-editor class="gf-form-label query-part"></span>
-        </div>
-        <div class="gf-form dropdown">
-          <span datadog-add-func></span>
-        </div>
-  
-        <div class="gf-form gf-form--grow">
-          <div class="gf-form-label gf-form-label--grow"></div>
-        </div>
-  
+
+      <div class="gf-form gf-form--grow">
+        <div class="gf-form-label gf-form-label--grow"></div>
       </div>
-  
-      <div class="gf-form-inline">
-        <div class="gf-form max-width-30">
-          <label class="gf-form-label query-keyword width-7">GROUP BY</label>
-          <input type="text" class="gf-form-input" ng-model="ctrl.target.groups" spellcheck='false' placeholder="Tags (separate by comma)" ng-blur="ctrl.refresh()">
-        </div>
-  
-        <div class="gf-form gf-form--grow">
-          <div class="gf-form-label gf-form-label--grow"></div>
-        </div>
-      </div>
-  
-      <div class="gf-form-inline">
-        <div class="gf-form max-width-30">
-          <label class="gf-form-label query-keyword width-7">ALIAS BY</label>
-          <input type="text" class="gf-form-input" ng-model="ctrl.target.alias" spellcheck='false' placeholder="Naming pattern" ng-blur="ctrl.refresh()">
-        </div>
-  
-        <div class="gf-form gf-form--grow">
-          <div class="gf-form-label gf-form-label--grow"></div>
-        </div>
-      </div>
-  
     </div>
-  
-  </query-editor-row>
+
+    <div class="gf-form-inline">
+      <div class="gf-form">
+        <label class="gf-form-label query-keyword width-7">FUNCS</label>
+      </div>
+
+      <div ng-repeat="func in ctrl.functions" class="gf-form">
+        <span datadog-func-editor class="gf-form-label query-part"></span>
+      </div>
+      <div class="gf-form dropdown">
+        <span datadog-add-func></span>
+      </div>
+
+      <div class="gf-form gf-form--grow">
+        <div class="gf-form-label gf-form-label--grow"></div>
+      </div>
+
+    </div>
+
+    <div class="gf-form-inline">
+      <div class="gf-form max-width-30">
+        <label class="gf-form-label query-keyword width-7">GROUP BY</label>
+        <input type="text" class="gf-form-input" ng-model="ctrl.target.groups" spellcheck='false' placeholder="Tags (separate by comma)" ng-blur="ctrl.refresh()">
+      </div>
+
+      <div class="gf-form gf-form--grow">
+        <div class="gf-form-label gf-form-label--grow"></div>
+      </div>
+    </div>
+
+    <div class="gf-form-inline">
+      <div class="gf-form max-width-30">
+        <label class="gf-form-label query-keyword width-7">ALIAS BY</label>
+        <input type="text" class="gf-form-input" ng-model="ctrl.target.alias" spellcheck='false' placeholder="Naming pattern" ng-blur="ctrl.refresh()">
+      </div>
+
+      <div class="gf-form gf-form--grow">
+        <div class="gf-form-label gf-form-label--grow"></div>
+      </div>
+    </div>
+
+  </div>
+
+</query-editor-row>

--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -92,6 +92,15 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
             _this.metricSegment = new uiSegmentSrv.newSelectMetric();
           }
 
+          if (_this.metricPrefix) {
+            _this.metricPrefixSegment = new uiSegmentSrv.newSegment(_this.metricPrefix);
+          } else {
+            _this.metricPrefixSegment = new uiSegmentSrv.newSegment({
+              fake: true,
+              value: 'select metric prefix'
+            });
+          }
+
           _this.target.tags = _this.target.tags || [];
           _this.tagSegments = _this.target.tags.map(uiSegmentSrv.newSegment);
           _this.fixTagSegments();
@@ -300,7 +309,12 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
         }, {
           key: 'getMetrics',
           value: function getMetrics() {
-            return this.datasource.initMetricsFetching(this.metricKeyword).then(this.uiSegmentSrv.transformToSegments(true));
+            return this.datasource.fetchMetricsFromPrefix(this.metricPrefix).then(this.uiSegmentSrv.transformToSegments(true));
+          }
+        }, {
+          key: 'getMetricPrefixes',
+          value: function getMetricPrefixes() {
+            return this.datasource.fetchMetrics().then(this.uiSegmentSrv.transformToSegments(true));
           }
         }, {
           key: 'getAggregations',
@@ -338,6 +352,14 @@ System.register(['lodash', './dfunc', 'app/plugins/sdk', './func_editor', './add
             this.target.metric = this.metricSegment.value;
             this.panelCtrl.refresh();
           }
+        }, {
+          key: 'prefixChanged',
+          value: function prefixChanged() {
+            // when the prefixes exist, metrics should have been already cached.
+            // therefore could directly start filtering
+            this.metricPrefix = this.metricPrefixSegment.value;
+            this.panelCtrl.refresh();
+          } 
         }, {
           key: 'asChanged',
           value: function asChanged() {


### PR DESCRIPTION
**Changes**
1.  Added an extra dropdown menu showing all metric prefixes
2. After selecting a prefix, the original `select metric` dropdown will show all the metrics associated to that prefix.

**Performance**
(courtesy to Emmanuel) Now, as soon as `select metric prefix` is clicked, all metrics will be stored in a dictionary with their corresponding prefixes as the keys. This avoid unnecessary HTTP requests in the future. Also, by grouping the metrics together, it could generally avoid loading a massive amount of metrics at once to crash the browser.